### PR TITLE
Patch ColorTag

### DIFF
--- a/lib/src/default_tags/basic_tags.dart
+++ b/lib/src/default_tags/basic_tags.dart
@@ -64,15 +64,20 @@ class ColorTag extends StyleTag {
   @override
   TextStyle transformStyle(
       TextStyle oldStyle, Map<String, String>? attributes) {
+    RegExp hexColorRegExp = RegExp(r'^#?[0-9a-f]{6}$',caseSensitive : false);
+    
     if (attributes?.entries.isEmpty ?? true) {
       return oldStyle;
     }
 
-    String? hexColor = attributes?.entries.first.key;
-    if (hexColor == null) return oldStyle;
-    return oldStyle.copyWith(color: HexColor.fromHex(hexColor));
+    String? hexColor = attributes?.entries.first.key ?? "";
+    
+    if(hexColorRegExp.hasMatch(hexColor)){
+      return oldStyle.copyWith(color: HexColor.fromHex(hexColor));
+    }
+
+    return oldStyle;
   }
-}
 
 /// Basic implementation of the [h<number>] tag.
 /// [_textSize] is used to define the new textSize.

--- a/lib/src/default_tags/basic_tags.dart
+++ b/lib/src/default_tags/basic_tags.dart
@@ -78,6 +78,7 @@ class ColorTag extends StyleTag {
 
     return oldStyle;
   }
+}
 
 /// Basic implementation of the [h<number>] tag.
 /// [_textSize] is used to define the new textSize.


### PR DESCRIPTION
filter unformat HEXColor to prevent FormatException crash.

my Example:
```dart
BBCodeText(
          data: 
          "[color=#ffffff]test[/color] \n" 
          "[color=ffffff]test[/color] \n" 
          "[color=33ffffff]test[/color]" //typo
          "[color=RED]test[/color]", //otherReason
          stylesheet: BBStylesheet(
            tags: [PatchColorTag()],
          )
        )
        
 ...
//colorTag
 if(hexColorRegExp.hasMatch(hexColor)){
    debugPrint("match it: $hexColor");
    return oldStyle.copyWith(color: HexColor.fromHex(hexColor));
  }
        
```

output:
flutter: match it: #ffffff
flutter: match it: ffffff